### PR TITLE
Use Ecto.Type 

### DIFF
--- a/lib/ecto_enum/use.ex
+++ b/lib/ecto_enum/use.ex
@@ -7,7 +7,7 @@ defmodule EctoEnum.Use do
     quote bind_quoted: [opts: opts] do
       typespec = Typespec.make(Keyword.keys(opts))
 
-      @behaviour Ecto.Type
+      use Ecto.Type
 
       @type t :: unquote(typespec)
 


### PR DESCRIPTION
This removes warnings about `embed_as` not being defined in Ecto >= 3.2.